### PR TITLE
Revert "delete: remove unused Home component from index.tsx"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const config = {
   title: "Glific",
   tagline: "An open source two way communication platform",
   url: "https://glific.github.io",
-  baseUrl: "/",
+  baseUrl: `/${process.env.BASE_URL ? process.env.BASE_URL : ""}`,
   customFields: {
     baseUrlRedirect: process.env.BASE_URL,
   },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Redirect } from "@docusaurus/router";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+export default function Home(): JSX.Element {
+    const { siteConfig } = useDocusaurusContext();
+    return (
+        <Redirect
+            to={`${siteConfig.customFields.baseUrlRedirect}/Glific%20Overview`}
+        />
+    );
+}


### PR DESCRIPTION
Reverts glific/docs#404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homepage now automatically redirects to the Glific Overview page for quicker access, improving navigation from the root URL.
* **Chores**
  * Base URL is now derived from an environment variable, enabling hosting under a custom subpath when set and defaulting to root when not. No content changes affected overall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->