### PR TITLE
Custom certificate: Added recommended way to use service account

### DIFF
--- a/docs/4. Product Features/Custom Certificates.md
+++ b/docs/4. Product Features/Custom Certificates.md
@@ -104,6 +104,9 @@ The presentation will open in a new window and automatically save in your Google
 - Ensure that the slide template does not end with “...slide=id.p1”
 - Ensure that the slide template is saved on the Google Drive linked to organization email id.
 
+10. Create the slides inside a folder located in the shared drive. Then, share that folder with the service account
+ and assign it the Content Manager role.
+
 ### 2. Save the certificate template in Glific
 
 1. On the Glific platform, go to `Flows` -> `Certificates` -> `Create` to add a new certificate template


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the Custom Certificates guide to include a new Google Slides setup step: create slides in a Shared Drive folder and share that folder with the service account, granting Content Manager access. This clarifies permissions requirements, helping prevent access errors and ensuring smoother certificate generation workflows for users integrating with Google Slides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->