### PR TITLE
Added info and screenshots for share repsonder links

### DIFF
--- a/docs/4. Product Features/03. Flows/1. Flow Overview.md
+++ b/docs/4. Product Features/03. Flows/1. Flow Overview.md
@@ -1,3 +1,14 @@
+# Flow Overview
+<h3>
+ <table>
+  <tr>
+    <td><b>5 minutes read</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Level: Beginner</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: October 2025</b></td>
+  </tr>
+</table>
+</h3>
+
 ## Flow Listing Page
 You will be taken to the `Flow Listing Page` on clicking the `Flows` tab in the Left Panel. All the Flows created will be listed here. 
 <img width="1367" height="751" alt="Screenshot 2025-10-07 at 3 37 31 PM" src="https://github.com/user-attachments/assets/4300a578-4b39-4622-bb56-80dbb8c41811" />

--- a/docs/4. Product Features/03. Flows/1. Flow Overview.md
+++ b/docs/4. Product Features/03. Flows/1. Flow Overview.md
@@ -1,7 +1,6 @@
-> ### **2 minute read &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `Beginner`**
-
 ## Flow Listing Page
 You will be taken to the `Flow Listing Page` on clicking the `Flows` tab in the Left Panel. All the Flows created will be listed here. 
+<img width="1367" height="751" alt="Screenshot 2025-10-07 at 3 37 31 PM" src="https://github.com/user-attachments/assets/4300a578-4b39-4622-bb56-80dbb8c41811" />
 
 ## Flow Listing Page Buttons
 
@@ -86,6 +85,19 @@ c) After publishing the flow, it will appear in the active flows section.
 
 <img width="1456" alt="image" src="https://github.com/user-attachments/assets/bd893a91-01c6-449a-b691-c9eea6f3284b"/>
 
-
-
 - The upwards arrow will give the information on the descending order of the flows created, last published.
+
+## Share WhatsApp links to your flows
+
+Once the flows are created, the next and the most important step is to share the links or QR codes that invite your beneficiaries to start the chat with your chatbot number on WhatsApp
+
+You can generate these WhatsApp keyword encoded links by clicking on the "share" icon.
+<img width="1231" height="280" alt="Screenshot 2025-10-03 at 3 56 52 PM" src="https://github.com/user-attachments/assets/0efd7c42-2231-43eb-8adb-93489d19b106" />
+
+This opens the window with the WhatsApp link and QR code for the associated keywords with a flow. Use the dropdown to select the keyword for which the link and QR code should be generated. 
+
+<img width="815" height="419" alt="Screenshot 2025-10-07 at 3 57 12 PM" src="https://github.com/user-attachments/assets/3e39d51e-4841-4e74-bfd0-2e2e5bd8239e" />
+
+Note: Clicking on the keyword links brings the contact to the WhatsApp chat with your chatbot with the keyword typed, The users must be explicitly instructed to click "Send" button on WhatsApp to start the conversation with the chatbot.
+
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a Flow Overview header with read-time and metadata.
  - Inserted a Flow Listing Page image to clarify layout.
  - Added a "Share WhatsApp links to your flows" guide showing keyword-encoded links, QR codes, and UI screenshots.
  - Included instructions to tap a keyword to open WhatsApp and press "Send" to start a chat.
  - Clarified that an upward arrow indicates flows are listed in descending order.
  - Note: the new WhatsApp share section appears twice in the document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->