### PR TITLE
refactor: :recycle: Update Google Sheets docs for date format.

### DIFF
--- a/docs/4. Product Features/03. Flows/2. Flow Actions/12. Link Google Sheets.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/12. Link Google Sheets.md
@@ -61,7 +61,7 @@ ___
 
 _As per above example, the sheet `Daily Activity` is used to read the content from, and the variable `@calendar.current_date`  DD/MM/YYYY being passed from Glific to the Google sheet is being used as the search key to identify the relevant row to send the content from_
 
-**Note**: It is important to note that dates in the sheet should be in the format `DD/MM/YYYY`. Any other format will not work as expected.
+**Note**: It is important to note that dates in the sheet should be in the format `DD/MM/YYYY`. Any other format will not work as expected. You could either set the Locale in the Google sheet to India or set the format of the column to `DD/MM/YYYY` here `Format -> Number -> Custom Date and Time`
 
 These all are the below calendar functions that can be used :
 `@calendar.current_date`,`@calendar.yesterday`,`@calendar.tomorrow`,`@calendar.current_day`,`@calendar.current_month`,


### PR DESCRIPTION
Clarify that dates must be in DD/MM/YYYY format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized example date format to DD/MM/YYYY.
  * Added guidance that Google Sheets dates must use DD/MM/YYYY for correct matching, with locale/custom format tips.
  * Introduced a prominent Note highlighting required date format and impact if misformatted.
  * Expanded calendar reference list to include @calendar.current_year.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->