### PR TITLE
Update 06.  HSM Templates.md

### DIFF
--- a/docs/4. Product Features/06.  HSM Templates.md
+++ b/docs/4. Product Features/06.  HSM Templates.md
@@ -109,9 +109,9 @@ _(Ensure Title and Template Name are not identical to avoid mapping issues.)_
 - Sending a message about online training. The requirement is that all users visit the same registration page.
 Button Title: Register Now
 
-- Button Value: https//xyz.org/register
+- Button Value: `https://xyz.org/register`
 
-- All users will see the button “Register Now” and clicking it will take them to https//xyz.org/register
+- All users will see the button “Register Now” and clicking it will take them to `https://xyz.org/register`
 
 **Dynamic URL**
 
@@ -124,9 +124,9 @@ Button Title: Register Now
 
 - Send a personalized health report to each user.
 - Button Title: View Report.
-- Button Value: https//xyz.org/report/{{1}}
+- Button Value: `https://xyz.org/report/{{1}}`
 
-- Sample Suffi- x: 12345 (so the full link becomes https//xyz.org/report/12345)
+- Sample Suffi- x: 12345 (so the full link becomes `https://xyz.org/report/12345`)
 
 - When sent, `{{1}}` will be replaced by the user's specific ID, like 12345 or abc678.
 


### PR DESCRIPTION
changed the exmaples format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the HSM Templates guide to standardize example URLs: sample static and dynamic URL examples are now shown in inline code format (e.g., `https://xyz.org/...`).
  * Replaced previous domain examples and adjusted Button Value example text for consistency.
  * No functional changes; this improves clarity and readability of documentation examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->