### PR TITLE
Revise last updated date and add access instructions

### DIFF
--- a/docs/4. Product Features/03. Flows/2. Flow Actions/12. Link Google Sheets.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/12. Link Google Sheets.md
@@ -4,7 +4,7 @@ ___
   <tr>
     <td><b>15 minutes read</b></td>
     <td style={{ paddingLeft: '40px' }}><b>Level: Intermediate</b></td>
-    <td style={{ paddingLeft: '40px' }}><b>Last Updated: December 2025</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: March 2026</b></td>
   </tr>
 </table>
 </h3>
@@ -381,6 +381,22 @@ Paste the service account credentials in the provided field, and click on the `S
 26. Open the Google Sheet to check the newly inserted data.
 <img width="1200" alt="Screenshot 2023-05-18 at 11 58 31 PM" src="https://github.com/glific/docs/assets/40158831/bfa12d80-9038-4c2a-919a-ce425bd2ffee"></img>
 ___
+
+### Google Sheet Access via Service Account
+
+To ensure sensitive beneficiary data (PII) is protected,avoid linking Google Sheets in Anyone can read or Anyone can read/write modes. 
+
+Instead, configure access via the Google Service Account linked to your Glific instance.
+
+
+Open the Google Sheet you want to link.
+
+Click Share → Paste the service account email (from the JSON key) and set the permission to either Viewer (read-only) or Editor (read/write).
+Link Sheet in Glific
+Now the sheet will be access via the service account, respecting the permissions set.
+
+
+<img width="412" height="484" alt="image" src="https://github.com/user-attachments/assets/e97a9d12-d25e-47fd-87ff-d796701ad59f" />
 
 ## Note
 

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/12. Link Google Sheets.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/12. Link Google Sheets.md
@@ -4,7 +4,7 @@ ___
   <tr>
     <td><b>15 minutes read</b></td>
     <td style={{ paddingLeft: '40px' }}><b>Level: Intermediate</b></td>
-    <td style={{ paddingLeft: '40px' }}><b>Last Updated: March 2026</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: April 2026</b></td>
   </tr>
 </table>
 </h3>

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/12. Link Google Sheets.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/12. Link Google Sheets.md
@@ -42,7 +42,9 @@ ___
 
 <img width="413" alt="Screenshot 2024-02-29 at 1 38 46 PM" src="https://github.com/glific/docs/assets/141305477/2612f184-eb99-4e02-aca9-6b4c1adbec16"/>
 
-5. Open the Google sheet and click on share button on the right hand side to update the sheet permission with the service account email (from the JSON key) and set the permission to either Viewer (read-only) or Editor (read/write).
+5. Open the Google Sheet and click on the share button on the top right. Add the service account email (from the JSON key) and grant the required access—Viewer (read-only) or Editor (read/write).
+
+Alternatively, if you prefer not to add the service account email, you can change the sheet persmission to “Anyone with the link can view.”
 
 
 6. Copy the URL

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/12. Link Google Sheets.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/12. Link Google Sheets.md
@@ -42,9 +42,8 @@ ___
 
 <img width="413" alt="Screenshot 2024-02-29 at 1 38 46 PM" src="https://github.com/glific/docs/assets/141305477/2612f184-eb99-4e02-aca9-6b4c1adbec16"/>
 
-5. Open the Google sheet and click on share button on the right hand side to update the sheet permission to at least `Anyone with the link` can `View`
+5. Open the Google sheet and click on share button on the right hand side to update the sheet permission with the service account email (from the JSON key) and set the permission to either Viewer (read-only) or Editor (read/write).
 
-![image](https://user-images.githubusercontent.com/32592458/219550695-58224a6f-4312-4981-b518-1dd6de639e3a.png)
 
 6. Copy the URL
 
@@ -323,7 +322,7 @@ Paste the service account credentials in the provided field, and click on the `S
 
 <img width="466" alt="Screenshot 2024-02-29 at 2 19 43 PM" src="https://github.com/glific/docs/assets/141305477/e85d0288-8751-4160-9a2c-11bff43f53fa"/>
 
-9. Open the Google Sheet you want to write data on and click on the share button on the right-hand side. Update the sheet permissions and add the Service Account Identifier (The client email on the service account) as a user invited in the spreadsheet's Collaboration Settings with `Editor` permission.
+8. Open the Google Sheet you want to write data on and click on the share button on the right-hand side. Update the sheet permissions and add the Service Account Identifier (The client email on the service account) as a user invited in the spreadsheet's Collaboration Settings with `Editor` permission.
 
 <img width="1200" alt="Screenshot 2023-05-18 at 11 23 49 PM" src="https://github.com/glific/docs/assets/40158831/feb09bd0-1d91-43ac-a289-ac813c2a2d4a"></img>
 
@@ -337,30 +336,30 @@ Paste the service account credentials in the provided field, and click on the `S
 
 ### Configuring Writable Google Sheet in the Flow
 
-12. Import the below sample flow  from the Flow screen and click on `setting` icon to configure it.
+11. Import the below sample flow  from the Flow screen and click on `setting` icon to configure it.
 
 **Sample Flow**
 
 [Write to Google Sheet.json](https://drive.google.com/file/d/17AQ507LDoMx7-Us_fZxlvpOuKgDhV5AV/view?usp=sharing)
 
 
-13. Here's how the imported flow would look like
+12. Here's how the imported flow would look like
 
 <img width="589" alt="Screenshot 2024-02-29 at 2 40 13 PM" src="https://github.com/glific/docs/assets/141305477/2edeafc6-19fa-4241-9224-6dafdde84519" />
 
 
-14. The first node is the `Send Message` node, which asks the contact for input to be added to the sheet.
+13. The first node is the `Send Message` node, which asks the contact for input to be added to the sheet.
 
-15. The second node is the `Wait for Response` node with the result name sheet_input. The response from the contact will be saved in this result and can be referenced as `@results.sheet_input`.
+14. The second node is the `Wait for Response` node with the result name sheet_input. The response from the contact will be saved in this result and can be referenced as `@results.sheet_input`.
 
-16. The third node is the `Link Google sheet` node, used to add the user-entered text into the Google sheet. Click on this node to configure it.
+15. The third node is the `Link Google sheet` node, used to add the user-entered text into the Google sheet. Click on this node to configure it.
 
 <img width="627" alt="Screenshot 2024-09-25 at 10 53 03 AM" src="https://github.com/user-attachments/assets/c5f6f422-91a0-48cb-bd98-bdb2d351fa6b"/>
 
-17. Under Action, select `Write` from the dropdown menu.
-18. From the next dropdown select the sheet which was added in the earlier step
-19. Specify the name of the subsheet where the content needs to be written
-20. Specify the starting cell to start writing from
+16. Under Action, select `Write` from the dropdown menu.
+17. From the next dropdown select the sheet which was added in the earlier step
+18. Specify the name of the subsheet where the content needs to be written
+19. Specify the starting cell to start writing from
 
 <img width="608" alt="Screenshot 2024-09-25 at 10 57 35 AM" src="https://github.com/user-attachments/assets/910c2af7-b9c6-45d4-97a0-56611f097811"/>
 
@@ -370,15 +369,15 @@ Paste the service account credentials in the provided field, and click on the `S
 
 21. After configuring the flow, click on the `Preview` button located on the top right side of the screen to run the flow in the simulator.
 
-23. In the simulator, you will see the first message from the `Send Message` node, which prompts you to enter text.
+22. In the simulator, you will see the first message from the `Send Message` node, which prompts you to enter text.
 
-24. Type the desired text that you want to see in the sheet, and then press Enter.
+23. Type the desired text that you want to see in the sheet, and then press Enter.
 
 <img width="845" alt="Screenshot 2024-02-29 at 2 36 46 PM" src="https://github.com/glific/docs/assets/141305477/c6d482ce-1419-4dc6-bbcd-2ecdf846dc6b" />
 
-25. This will move the flow forward, and the data will be written to the Google Sheet.
+24. This will move the flow forward, and the data will be written to the Google Sheet.
 
-26. Open the Google Sheet to check the newly inserted data.
+25. Open the Google Sheet to check the newly inserted data.
 <img width="1200" alt="Screenshot 2023-05-18 at 11 58 31 PM" src="https://github.com/glific/docs/assets/40158831/bfa12d80-9038-4c2a-919a-ce425bd2ffee"></img>
 ___
 
@@ -389,11 +388,11 @@ To ensure sensitive beneficiary data (PII) is protected,avoid linking Google She
 Instead, configure access via the Google Service Account linked to your Glific instance.
 
 
-Open the Google Sheet you want to link.
+1.Open the Google Sheet you want to link.
 
-Click Share → Paste the service account email (from the JSON key) and set the permission to either Viewer (read-only) or Editor (read/write).
-Link Sheet in Glific
-Now the sheet will be access via the service account, respecting the permissions set.
+2. Click Share → Paste the service account email (from the JSON key) and set the permission to either Viewer (read-only) or Editor (read/write).
+3. Link Sheet in Glific
+4. Now the sheet will be access via the service account, respecting the permissions set.
 
 
 <img width="412" height="484" alt="image" src="https://github.com/user-attachments/assets/e97a9d12-d25e-47fd-87ff-d796701ad59f" />


### PR DESCRIPTION
Updated last updated date and added section on Google Sheet access via Service Account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Google Sheets linking docs and "Last Updated" metadata to April 2026.
  * Replaced generic "anyone with the link" guidance with steps to share sheets with the service account email (Viewer or Editor), while keeping an alternative link-based sharing option.
  * Added a new "Google Sheet Access via Service Account" section with a new illustrative image, removed the prior screenshot, and renumbered writable-setup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->