### PR TITLE
docs: add FAQ for "BigQuery Streaming Insert Not Allowed in Free Tier" error

### DIFF
--- a/docs/8. FAQ/Fixing BigQuery Streaming Insert Not Allowed in Free Tier Error.md
+++ b/docs/8. FAQ/Fixing BigQuery Streaming Insert Not Allowed in Free Tier Error.md
@@ -1,0 +1,32 @@
+<h3>
+ <table>
+  <tr>
+    <td><b> 3 minutes read</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Level: Intermediate </b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: July 2026</b></td>
+  </tr>
+</table>
+</h3>
+
+# Fixing "Access Denied: BigQuery Streaming Insert Not Allowed in Free Tier" Error
+
+Glific writes every message and contact update into your BigQuery account in real time, using what Google calls a "streaming insert". If your Google Cloud project's billing account is not fully set up, these writes fail and this error shows up in your BigQuery sync.
+
+## Why this happens
+
+BigQuery has a generous free tier for storage and queries (refer [BigQuery Setup and link with Glific](https://glific.github.io/docs/docs/Product%20Features/Reporting%20&%20Dashboard/BigQuery%20Setup%20and%20link%20with%20Glific/) to know more), but streaming inserts are a separate, billable feature. Google requires a project to have an active, upgraded billing account before it will accept streaming inserts - even if your actual usage stays well within the free tier limits. This error usually means one of the following:
+
+- No billing account is linked to the Google Cloud project connected to Glific, or
+- The project is still on Google Cloud's 90-day free trial, which has not been upgraded to a full billing account.
+
+## How to fix this
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/) and sign in with the account used to set up BigQuery for your organization.
+2. Select the same project that is linked to Glific for BigQuery (refer [BigQuery Setup and link with Glific](https://glific.github.io/docs/docs/Product%20Features/Reporting%20&%20Dashboard/BigQuery%20Setup%20and%20link%20with%20Glific/) if you're not sure which project this is).
+3. From the left navigation menu, select `Billing`.
+4. If you see an option to `Upgrade`, select it and complete the steps to convert your free trial to a full Cloud Billing account. If no billing account is linked at all, select `Link a billing account` and either choose an existing one or create a new one.
+5. Add a valid payment method when prompted, and confirm.
+
+Once billing is upgraded/linked, streaming inserts into BigQuery will resume automatically. You don't need to change anything in Glific - Glific will keep sending data as soon as your Google Cloud project accepts it.
+
+Please Note : Upgrading or linking a billing account does not mean you'll be charged immediately. BigQuery's free tier (10GB storage and 1TB of queries per month) still applies - you'll only be billed if you exceed those limits, and Google notifies you before that happens.

--- a/docs/8. FAQ/Fixing BigQuery Streaming Insert Not Allowed in Free Tier Error.md
+++ b/docs/8. FAQ/Fixing BigQuery Streaming Insert Not Allowed in Free Tier Error.md
@@ -8,18 +8,18 @@
 </table>
 </h3>
 
-# Fixing "Access Denied: BigQuery Streaming Insert Not Allowed in Free Tier" Error
+# BigQuery Streaming Insert Not Allowed in Free Tier:
 
 Glific writes every message and contact update into your BigQuery account in real time, using what Google calls a "streaming insert". If your Google Cloud project's billing account is not fully set up, these writes fail and this error shows up in your BigQuery sync.
 
-## Why this happens
+## Why this happens:
 
 BigQuery has a generous free tier for storage and queries (refer [BigQuery Setup and link with Glific](https://glific.github.io/docs/docs/Product%20Features/Reporting%20&%20Dashboard/BigQuery%20Setup%20and%20link%20with%20Glific/) to know more), but streaming inserts are a separate, billable feature. Google requires a project to have an active, upgraded billing account before it will accept streaming inserts - even if your actual usage stays well within the free tier limits. This error usually means one of the following:
 
 - No billing account is linked to the Google Cloud project connected to Glific, or
 - The project is still on Google Cloud's 90-day free trial, which has not been upgraded to a full billing account.
 
-## How to fix this
+## How to fix this:
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com/) and sign in with the account used to set up BigQuery for your organization.
 2. Select the same project that is linked to Glific for BigQuery (refer [BigQuery Setup and link with Glific](https://glific.github.io/docs/docs/Product%20Features/Reporting%20&%20Dashboard/BigQuery%20Setup%20and%20link%20with%20Glific/) if you're not sure which project this is).

--- a/docs/8. FAQ/Fixing BigQuery Streaming Insert Not Allowed in Free Tier Error.md
+++ b/docs/8. FAQ/Fixing BigQuery Streaming Insert Not Allowed in Free Tier Error.md
@@ -14,15 +14,15 @@ Glific writes every message and contact update into your BigQuery account in rea
 
 ## Why this happens
 
-BigQuery has a generous free tier for storage and queries (refer [BigQuery Setup and link with Glific](https://glific.github.io/docs/docs/Product%20Features/Reporting%20&%20Dashboard/BigQuery%20Setup%20and%20link%20with%20Glific/) to know more), but streaming inserts are a separate, billable feature. Google requires a project to have an active, upgraded billing account before it will accept streaming inserts - even if your actual usage stays well within the free tier limits. This error usually means one of the following:
+BigQuery has a generous free tier for storage and queries (refer to the BigQuery Setup and link with Glific page to know more), but streaming inserts are a separate, billable feature. Google requires a project to have an active, upgraded billing account before it will accept streaming inserts - even if your actual usage stays well within the free tier limits. This error usually means one of the following:
 
 - No billing account is linked to the Google Cloud project connected to Glific, or
 - The project is still on Google Cloud's 90-day free trial, which has not been upgraded to a full billing account.
 
 ## How to fix this
 
-1. Go to [Google Cloud Console](https://console.cloud.google.com/) and sign in with the account used to set up BigQuery for your organization.
-2. Select the same project that is linked to Glific for BigQuery (refer [BigQuery Setup and link with Glific](https://glific.github.io/docs/docs/Product%20Features/Reporting%20&%20Dashboard/BigQuery%20Setup%20and%20link%20with%20Glific/) if you're not sure which project this is).
+1. Go to Google Cloud Console (console.cloud.google.com) and sign in with the account used to set up BigQuery for your organization.
+2. Select the same project that is linked to Glific for BigQuery (refer to the BigQuery Setup and link with Glific page if you're not sure which project this is).
 3. From the left navigation menu, select `Billing`.
 4. If you see an option to `Upgrade`, select it and complete the steps to convert your free trial to a full Cloud Billing account. If no billing account is linked at all, select `Link a billing account` and either choose an existing one or create a new one.
 5. Add a valid payment method when prompted, and confirm.

--- a/docs/8. FAQ/Fixing BigQuery Streaming Insert Not Allowed in Free Tier Error.md
+++ b/docs/8. FAQ/Fixing BigQuery Streaming Insert Not Allowed in Free Tier Error.md
@@ -24,9 +24,13 @@ BigQuery has a generous free tier for storage and queries (refer [BigQuery Setup
 1. Go to [Google Cloud Console](https://console.cloud.google.com/) and sign in with the account used to set up BigQuery for your organization.
 2. Select the same project that is linked to Glific for BigQuery (refer [BigQuery Setup and link with Glific](https://glific.github.io/docs/docs/Product%20Features/Reporting%20&%20Dashboard/BigQuery%20Setup%20and%20link%20with%20Glific/) if you're not sure which project this is).
 3. From the left navigation menu, select Billing.
+
+<img width="271" height="381" alt="image" src="https://github.com/user-attachments/assets/34e61468-afae-4062-af24-75967e055ca4" />
+
 4. If you see an option to Upgrade, select it and complete the steps to convert your free trial to a full Cloud Billing account. If no billing account is linked at all, select Link a billing account and either choose an existing one or create a new one.
 5. Add a valid payment method when prompted, and confirm.
 
 Once billing is upgraded/linked, streaming inserts into BigQuery will resume automatically. You don't need to change anything in Glific - Glific will keep sending data as soon as your Google Cloud project accepts it.
 
-Please Note : Upgrading or linking a billing account does not mean you'll be charged immediately. BigQuery's free tier (10GB storage and 1TB of queries per month) still applies - you'll only be billed if you exceed those limits, and Google notifies you before that happens.
+Please Note : Upgrading or linking a billing account does not mean you will be charged immediately. 
+BigQuery's free tier (10GB storage and 1TB of queries per month) still applies - you will only be billed if you exceed those limits, and Google notifies you before that happens.

--- a/docs/8. FAQ/Fixing BigQuery Streaming Insert Not Allowed in Free Tier Error.md
+++ b/docs/8. FAQ/Fixing BigQuery Streaming Insert Not Allowed in Free Tier Error.md
@@ -14,17 +14,17 @@ Glific writes every message and contact update into your BigQuery account in rea
 
 ## Why this happens
 
-BigQuery has a generous free tier for storage and queries (refer to the BigQuery Setup and link with Glific page to know more), but streaming inserts are a separate, billable feature. Google requires a project to have an active, upgraded billing account before it will accept streaming inserts - even if your actual usage stays well within the free tier limits. This error usually means one of the following:
+BigQuery has a generous free tier for storage and queries (refer [BigQuery Setup and link with Glific](https://glific.github.io/docs/docs/Product%20Features/Reporting%20&%20Dashboard/BigQuery%20Setup%20and%20link%20with%20Glific/) to know more), but streaming inserts are a separate, billable feature. Google requires a project to have an active, upgraded billing account before it will accept streaming inserts - even if your actual usage stays well within the free tier limits. This error usually means one of the following:
 
 - No billing account is linked to the Google Cloud project connected to Glific, or
 - The project is still on Google Cloud's 90-day free trial, which has not been upgraded to a full billing account.
 
 ## How to fix this
 
-1. Go to Google Cloud Console (console.cloud.google.com) and sign in with the account used to set up BigQuery for your organization.
-2. Select the same project that is linked to Glific for BigQuery (refer to the BigQuery Setup and link with Glific page if you're not sure which project this is).
-3. From the left navigation menu, select `Billing`.
-4. If you see an option to `Upgrade`, select it and complete the steps to convert your free trial to a full Cloud Billing account. If no billing account is linked at all, select `Link a billing account` and either choose an existing one or create a new one.
+1. Go to [Google Cloud Console](https://console.cloud.google.com/) and sign in with the account used to set up BigQuery for your organization.
+2. Select the same project that is linked to Glific for BigQuery (refer [BigQuery Setup and link with Glific](https://glific.github.io/docs/docs/Product%20Features/Reporting%20&%20Dashboard/BigQuery%20Setup%20and%20link%20with%20Glific/) if you're not sure which project this is).
+3. From the left navigation menu, select Billing.
+4. If you see an option to Upgrade, select it and complete the steps to convert your free trial to a full Cloud Billing account. If no billing account is linked at all, select Link a billing account and either choose an existing one or create a new one.
 5. Add a valid payment method when prompted, and confirm.
 
 Once billing is upgraded/linked, streaming inserts into BigQuery will resume automatically. You don't need to change anything in Glific - Glific will keep sending data as soon as your Google Cloud project accepts it.


### PR DESCRIPTION
## Summary

Fixes #323

Adds a new FAQ page explaining the `Access Denied: BigQuery Streaming Insert not allowed in the free tier` error reported on Discord:

- Why it happens: BigQuery's free tier covers storage/queries, but streaming inserts (how Glific writes messages/contacts into BigQuery in real time) require the Google Cloud project to have an upgraded or linked billing account — regardless of whether usage stays within free-tier limits.
- How to fix it: steps to upgrade the free trial / link a billing account in Google Cloud Console for the project connected to Glific.
- Reassurance that this doesn't mean immediate charges — the existing free-tier limits (10GB storage, 1TB queries/month) documented in "BigQuery Setup and link with Glific" still apply.

Cross-links to the existing `BigQuery Setup and link with Glific` page rather than duplicating its content.

## Verification

Confirmed the underlying cause against Google Cloud's documented behavior: streaming inserts (`tabledata.insertAll`) are blocked until a project's Cloud Billing account is upgraded past the free trial / linked, even when actual usage is within free-tier limits.

## Test plan

- [ ] Docs site renders the new FAQ page and shows up under the FAQ section (auto-generated index, no `_category_.json` changes needed)
- [ ] Reviewer confirms the fix steps match current Google Cloud Console UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ page explaining the “BigQuery Streaming Insert Not Allowed in Free Tier” error.
  * Clarified common causes, including missing billing setup and free-trial limitations.
  * Included step-by-step guidance for linking or upgrading billing so syncing can resume.
  * Noted that enabling billing does not necessarily mean immediate charges unless usage exceeds free-tier limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->