### PR TITLE
docs: rewrite Label the incoming message with best practices

### DIFF
--- a/docs/4. Product Features/03. Flows/2. Flow Actions/07. Label the incoming message.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/07. Label the incoming message.md
@@ -8,8 +8,6 @@
 </table>
 </h3>
 
-___
-
 **Labelling the incoming message flow action is used to categorize the messages into separate buckets. This helps you capture data points which can be used for creating reports, analytics etc.**
 
 For instance, if someone chooses English as their preferred language, you can label their message as 'English' and then generate charts for how many people chose English.

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/07. Label the incoming message.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/07. Label the incoming message.md
@@ -1,4 +1,13 @@
-> ### **2 minute read &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `Beginner`**
+<h3>
+ <table>
+  <tr>
+    <td><b> 3 minutes read</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Level: Beginner </b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: July 2026</b></td>
+  </tr>
+</table>
+</h3>
+
 ___
 
 **Labelling the incoming message flow action is used to categorize the messages into separate buckets. This helps you capture data points which can be used for creating reports, analytics etc.**

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/07. Label the incoming message.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/07. Label the incoming message.md
@@ -21,14 +21,15 @@ Because of this, the node only does something useful if there is a message from 
 ## Adding the node to your flow
 
 1. Add a `Label the incoming message` node at the point in your flow where you want to categorize the contact's message.
+
+ Tip - Place this node right after a `Wait for Response` node if you want to label what the contact just typed. This guarantees the incoming message being labelled is the reply you're interested in, not an older message from earlier in the conversation.
 2. Under `Select the labels to apply to the incoming message`, enter the name of an existing label or create a new one.
 3. Click `Ok` to save the node.
 
 ![Add Labels node showing the label selection field](https://user-images.githubusercontent.com/32592458/218254849-f5049dcb-4c84-4250-b235-efec35a43360.png)
 
-## Best practices
+## Note
 
-- Place this node right after a `Wait for Response` node if you want to label what the contact just typed. This guarantees the incoming message being labelled is the reply you're interested in, not an older message from earlier in the conversation.
 - If you add this node without a `Wait for Response` immediately before it (for example, right at the start of a flow, before the contact has said anything), there is no incoming message yet and the label is not applied to anything.
 - You can add more than one label to the same node. If the same message already has a label from an earlier point in the flow, the new label is added alongside it rather than replacing it.
 - Keep label names consistent across flows (for example, always use `English` rather than mixing `english` and `English`) so your reports and BigQuery analytics can group them correctly.

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/07. Label the incoming message.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/07. Label the incoming message.md
@@ -1,15 +1,35 @@
-> ### **1 minute read &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `Beginner`**
+> ### **2 minute read &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `Beginner`**
 ___
 
-**Labelling the incoming message flow action is used to categorize the messages into separate buckets. This helps you capture data points which can be used for creating reports, analytics etc.** 
+**Labelling the incoming message flow action is used to categorize the messages into separate buckets. This helps you capture data points which can be used for creating reports, analytics etc.**
 
-## Video Tutorial
+For instance, if someone chooses English as their preferred language, you can label their message as 'English' and then generate charts for how many people chose English.
+
+## How it works
+
+This node labels the contact's most recent incoming message - not any message the bot sends. Every time the flow runs this node, it adds the label(s) you choose to whichever message the contact sent last.
+
+Because of this, the node only does something useful if there is a message from the contact to label at that point in the flow.
+
+## Adding the node to your flow
+
+1. Add a `Label the incoming message` node at the point in your flow where you want to categorize the contact's message.
+2. Under `Select the labels to apply to the incoming message`, enter the name of an existing label or create a new one.
+3. Click `Ok` to save the node.
+
+![Add Labels node showing the label selection field](https://user-images.githubusercontent.com/32592458/218254849-f5049dcb-4c84-4250-b235-efec35a43360.png)
+
+## Best practices
+
+- Place this node right after a `Wait for Response` node if you want to label what the contact just typed. This guarantees the incoming message being labelled is the reply you're interested in, not an older message from earlier in the conversation.
+- If you add this node without a `Wait for Response` immediately before it (for example, right at the start of a flow, before the contact has said anything), there is no incoming message yet and the label is not applied to anything.
+- You can add more than one label to the same node. If the same message already has a label from an earlier point in the flow, the new label is added alongside it rather than replacing it.
+- Keep label names consistent across flows (for example, always use `English` rather than mixing `english` and `English`) so your reports and BigQuery analytics can group them correctly.
+
+---
+
+## Related video
+
+This video walks through building a full flow and includes an example of using the `Label the incoming message` node partway through - it's a good reference for seeing the node used in context, but isn't focused on this node alone.
 
 <iframe width="800" height="500" src="https://www.youtube.com/embed/Y2KWDO7SfnI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-
-<br />
-<br />
-
-**For instance, if someone chooses English as their preferred language, you can label their message as 'English' and then generate charts for how many people chose English.**
-
-![image](https://user-images.githubusercontent.com/32592458/218254849-f5049dcb-4c84-4250-b235-efec35a43360.png)


### PR DESCRIPTION
## Summary

Fixes #614

The `Label the incoming message` page was almost entirely a video embed, and per the issue, ~80% of that video isn't about this node - the part where it's actually used doesn't demonstrate correct usage either.

This replaces it with:

- **How it works**: explains that the node labels the contact's *last incoming message*, not any bot-sent message.
- **Adding the node to your flow**: concrete configuration steps against the existing "Add Labels" screenshot.
- **Best practices**: the specific guidance requested in the issue - place this node right after a `Wait for Response` node so the label lands on the reply you actually want, what happens if there's no incoming message yet (no-op), that multiple labels combine rather than overwrite, and to keep label names consistent for reporting.
- Keeps the video, but demoted to a "Related video" section at the bottom with a caveat that it's a broader flow-building walkthrough rather than being about this node specifically.

## Verification

Confirmed the node's actual behavior against `glific/glific`:
- `lib/glific/flows/action.ex` - `add_input_labels` execution labels `context.last_message`
- `lib/glific/processor/consumer_flow.ex` - `last_message` is set to the contact's message specifically in `continue_current_context`, which runs when a flow resumes after the contact replies (i.e., right after a `Wait for Response` node completes)
- `add_flow_label/2` no-ops when `last_message` is `nil`, confirming the node does nothing if there's no incoming message to attach a label to
- Existing labels and new labels are comma-joined rather than replaced

## Test plan

- [ ] Docs site renders the new sections and image correctly
- [ ] Reviewer confirms this matches the intended usage pattern for this node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Label the incoming message” page to set the read-time estimate to **3 minutes**.
  * Refreshed the page layout with clearer sections: **How it works**, **Adding the node to your flow** (step-by-step), and **Best practices / Notes**.
  * Moved the tutorial video into a dedicated **Related video** section near the end for better separation of guidance and media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->