### PR TITLE
docs: add AI fallback use case combining Label the incoming message and Open a ticket

### DIFF
--- a/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
@@ -175,6 +175,22 @@ Once a ticket is created, users can make edits by utilizing the `Add Remark` opt
 <img width="567" alt="image" src="https://github.com/glific/docs/assets/143380171/554f2688-426b-4019-9552-b351ebbe0f6c"/>
 
 
+## Use Case: Escalating unanswered AI queries to a human agent
+
+If you're using an AI Assistant to answer contact questions (see [File Search Using OpenAI Assistants](https://glific.github.io/docs/docs/Integrations/Filesearch%20Using%20OpenAI%20Assistants/)), some questions will fall outside what it can answer. `Label the incoming message` and `Open a ticket with a human agent` can be combined to automatically flag and route these to your team.
+
+1. Capture the contact's question with a `Wait for Response` node, then call your AI Assistant as usual.
+
+2. In your AI Assistant's Instructions, ask it to always reply with one clear, consistent phrase when it can't answer, for example "I'm not able to help with that yet." This gives the flow something reliable to check for.
+
+3. Add a [Split by a result in the flow](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Split%20By/Result%20in%20the%20Flow/) node on the assistant's response (e.g. `@results.gptresponse.message`). Create a branch matching that fallback phrase, or use the `Other` branch to catch anything that isn't one of the assistant's expected answers.
+
+4. On that branch, add a [Label the incoming message](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Label%20the%20incoming%20message) node and enter a label such as `AI_unhandled`. No other `Wait for Response` node runs between the contact's original question and this point, so the label still lands on that original question rather than on the AI's reply.
+
+5. Right after the label node, add an `Open a ticket with a human agent` node, following the steps above. Use `@results.<result name from step 1>` as the Ticket Body so the ticket shows the contact's original question, and assign it to the relevant staff member or queue.
+
+This way, every query the AI can't resolve is labeled `AI_unhandled` and immediately handed off as a ticket, so you can report on how often the assistant falls back and make sure nothing gets missed.
+
 ## Best Practices
 
 - Always assign tickets to the right staff to ensure faster resolution.

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
@@ -187,7 +187,7 @@ If you're using an AI Assistant to answer contact questions (see [File Search Us
 
 4. On that branch, add a [Label the incoming message](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Label%20the%20incoming%20message) node and enter a label such as AI_unhandled. No other Wait for Response node runs between the contact's original question and this point, so the label still lands on that original question rather than on the AI's reply.
 
-5. Right after the label node, add an Open a ticket with a human agent node, following the steps above. Use @results.<result name from step 1> as the Ticket Body so the ticket shows the contact's original question, and assign it to the relevant staff member or queue.
+5. Right after the label node, add an Open a ticket with a human agent node, following the steps above. Use `@results.<result name from step 1>` as the Ticket Body so the ticket shows the contact's original question, and assign it to the relevant staff member or queue.
 
 This way, every query the AI can't resolve is labeled AI_unhandled and immediately handed off as a ticket, so you can report on how often the assistant falls back and make sure nothing gets missed.
 

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
@@ -3,7 +3,7 @@
   <tr>
     <td><b>5 minutes read</b></td>
     <td style={{ paddingLeft: '40px' }}><b>Level: Advanced</b></td>
-    <td style={{ paddingLeft: '40px' }}><b>Last Updated: October 2025</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: July 2026</b></td>
   </tr>
 </table>
 </h3>
@@ -177,19 +177,19 @@ Once a ticket is created, users can make edits by utilizing the `Add Remark` opt
 
 ## Use Case: Escalating unanswered AI queries to a human agent
 
-If you're using an AI Assistant to answer contact questions (see [File Search Using OpenAI Assistants](https://glific.github.io/docs/docs/Integrations/Filesearch%20Using%20OpenAI%20Assistants/)), some questions will fall outside what it can answer. `Label the incoming message` and `Open a ticket with a human agent` can be combined to automatically flag and route these to your team.
+If you're using an AI Assistant to answer contact questions (see [File Search Using OpenAI Assistants](https://glific.github.io/docs/docs/Integrations/Filesearch%20Using%20OpenAI%20Assistants/)), some questions will fall outside what it can answer. Label the incoming message and Open a ticket with a human agent can be combined to automatically flag and route these to your team.
 
-1. Capture the contact's question with a `Wait for Response` node, then call your AI Assistant as usual.
+1. Capture the contact's question with a Wait for Response node, then call your AI Assistant as usual.
 
 2. In your AI Assistant's Instructions, ask it to always reply with one clear, consistent phrase when it can't answer, for example "I'm not able to help with that yet." This gives the flow something reliable to check for.
 
-3. Add a [Split by a result in the flow](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Split%20By/Result%20in%20the%20Flow/) node on the assistant's response (e.g. `@results.gptresponse.message`). Create a branch matching that fallback phrase, or use the `Other` branch to catch anything that isn't one of the assistant's expected answers.
+3. Add a [Split by a result in the flow](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Split%20By/Result%20in%20the%20Flow/) node on the assistant's response (e.g. @results.gptresponse.message). Create a branch matching that fallback phrase, or use the Other branch to catch anything that isn't one of the assistant's expected answers.
 
-4. On that branch, add a [Label the incoming message](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Label%20the%20incoming%20message) node and enter a label such as `AI_unhandled`. No other `Wait for Response` node runs between the contact's original question and this point, so the label still lands on that original question rather than on the AI's reply.
+4. On that branch, add a [Label the incoming message](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Label%20the%20incoming%20message) node and enter a label such as AI_unhandled. No other Wait for Response node runs between the contact's original question and this point, so the label still lands on that original question rather than on the AI's reply.
 
-5. Right after the label node, add an `Open a ticket with a human agent` node, following the steps above. Use `@results.<result name from step 1>` as the Ticket Body so the ticket shows the contact's original question, and assign it to the relevant staff member or queue.
+5. Right after the label node, add an Open a ticket with a human agent node, following the steps above. Use @results.<result name from step 1> as the Ticket Body so the ticket shows the contact's original question, and assign it to the relevant staff member or queue.
 
-This way, every query the AI can't resolve is labeled `AI_unhandled` and immediately handed off as a ticket, so you can report on how often the assistant falls back and make sure nothing gets missed.
+This way, every query the AI can't resolve is labeled AI_unhandled and immediately handed off as a ticket, so you can report on how often the assistant falls back and make sure nothing gets missed.
 
 ## Best Practices
 

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
@@ -189,9 +189,25 @@ If you're using an AI Assistant to answer contact questions (see [File Search Us
 
 5. On that branch, add a [Label the incoming message](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Label%20the%20incoming%20message) node and enter a label such as AI_unhandled. No other Wait for Response node runs between the contact's original question and this point, so the label still lands on that original question rather than on the AI's reply.
 
+
+
+
+
 6. Right after the label node, add an Open a ticket with a human agent node, following the steps above. Use `@results.<result name from step 1>` as the Ticket Body so the ticket shows the contact's original question, and assign it to the relevant staff member or queue.
 
-7. On the branch(es) that don't match the fallback phrase, continue as normal and send the assistant's reply (`@results.gptresponse.message`) to the contact.
+<img width="565" height="355" alt="image" src="https://github.com/user-attachments/assets/5be8f7ac-5fea-40c2-af2d-e2394a774c0f" />
+
+
+<img width="544" height="398" alt="image" src="https://github.com/user-attachments/assets/fdde70e2-dbff-4ee7-a094-7ef59cb1b576" />
+
+<br>
+
+
+<img width="463" height="463" alt="image" src="https://github.com/user-attachments/assets/966f9482-d9b0-4ace-a627-49c937ec69d0" />
+
+
+
+7. On the branches that don't match the fallback phrase, continue as normal and send the assistant's reply (`@results.gptresponse.message`) to the contact.
 
 You'll also want to handle the `Failure` exit of the Call a Webhook node separately - for example, by sending an error message or routing straight to a ticket - since that covers the webhook call itself failing, which is a different case from the assistant successfully responding with "I don't know."
 

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
@@ -179,15 +179,21 @@ Once a ticket is created, users can make edits by utilizing the `Add Remark` opt
 
 If you're using an AI Assistant to answer contact questions (see [File Search Using OpenAI Assistants](https://glific.github.io/docs/docs/Integrations/Filesearch%20Using%20OpenAI%20Assistants/)), some questions will fall outside what it can answer. Label the incoming message and Open a ticket with a human agent can be combined to automatically flag and route these to your team.
 
-1. Capture the contact's question with a Wait for Response node, then call your AI Assistant as usual.
+1. Capture the contact's question with a Wait for Response node.
 
-2. In your AI Assistant's Instructions, ask it to always reply with one clear, consistent phrase when it can't answer, for example "I'm not able to help with that yet." This gives the flow something reliable to check for.
+2. Call your AI Assistant with a Call a Webhook node, giving it a result name such as `gptresponse`. Like any Call a Webhook node, this has separate `Success` and `Failure` exits.
 
-3. Add a [Split by a result in the flow](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Split%20By/Result%20in%20the%20Flow/) node on the assistant's response (e.g. @results.gptresponse.message). Create a branch matching that fallback phrase, or use the Other branch to catch anything that isn't one of the assistant's expected answers.
+3. In your AI Assistant's Instructions, ask it to always reply with one clear, consistent phrase when it can't answer, for example "I'm not able to help with that yet." This gives the flow something reliable to check for.
 
-4. On that branch, add a [Label the incoming message](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Label%20the%20incoming%20message) node and enter a label such as AI_unhandled. No other Wait for Response node runs between the contact's original question and this point, so the label still lands on that original question rather than on the AI's reply.
+4. On the `Success` exit of the Call a Webhook node - before the assistant's reply is sent back to the contact - add a [Split by a result in the flow](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Split%20By/Result%20in%20the%20Flow/) node on `@results.gptresponse.message` (the assistant's response - `gptresponse` here is the result name you gave the Call a Webhook node in step 2, so adjust it if you used a different name). Create a branch matching that fallback phrase, or use the Other branch to catch anything that isn't one of the assistant's expected answers.
 
-5. Right after the label node, add an Open a ticket with a human agent node, following the steps above. Use `@results.<result name from step 1>` as the Ticket Body so the ticket shows the contact's original question, and assign it to the relevant staff member or queue.
+5. On that branch, add a [Label the incoming message](https://glific.github.io/docs/docs/Product%20Features/Flows/Flow%20Actions/Label%20the%20incoming%20message) node and enter a label such as AI_unhandled. No other Wait for Response node runs between the contact's original question and this point, so the label still lands on that original question rather than on the AI's reply.
+
+6. Right after the label node, add an Open a ticket with a human agent node, following the steps above. Use `@results.<result name from step 1>` as the Ticket Body so the ticket shows the contact's original question, and assign it to the relevant staff member or queue.
+
+7. On the branch(es) that don't match the fallback phrase, continue as normal and send the assistant's reply (`@results.gptresponse.message`) to the contact.
+
+You'll also want to handle the `Failure` exit of the Call a Webhook node separately - for example, by sending an error message or routing straight to a ticket - since that covers the webhook call itself failing, which is a different case from the assistant successfully responding with "I don't know."
 
 This way, every query the AI can't resolve is labeled AI_unhandled and immediately handed off as a ticket, so you can report on how often the assistant falls back and make sure nothing gets missed.
 

--- a/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
+++ b/docs/4. Product Features/03. Flows/2. Flow Actions/16.  Open a ticket with a human agent.md
@@ -200,7 +200,7 @@ If you're using an AI Assistant to answer contact questions (see [File Search Us
 
 <img width="544" height="398" alt="image" src="https://github.com/user-attachments/assets/fdde70e2-dbff-4ee7-a094-7ef59cb1b576" />
 
-<br>
+<br />
 
 
 <img width="463" height="463" alt="image" src="https://github.com/user-attachments/assets/966f9482-d9b0-4ace-a627-49c937ec69d0" />


### PR DESCRIPTION
## Summary

Fixes #550

Adds a "Use Case: Escalating unanswered AI queries to a human agent" section to the `Open a ticket with a human agent` doc, answering the Discord question referenced in the issue:

1. How to add `Label the incoming message` in the AI fallback path so unhandled messages get labeled automatically (e.g. `AI_unhandled`).
2. How to add `Open a ticket with a human agent` right after labeling, so those queries route to a human agent.

The walkthrough covers:
- Capturing the contact's question, then calling the AI Assistant as usual
- Configuring the assistant's Instructions to return one consistent fallback phrase when it can't answer
- Using `Split by a result in the flow` on the assistant's response to branch on that fallback phrase (or the `Other` branch)
- Labeling that branch with `AI_unhandled` right there - since no `Wait for Response` runs between the contact's original question and this point, the label still lands on the original question, not the AI's reply
- Adding the `Open a ticket with a human agent` node immediately after, using the original question as the ticket body

Cross-links to the existing File Search / OpenAI Assistants doc, the Split by a Result in the Flow doc, and the Label the incoming message doc (recently expanded in #644) rather than duplicating their content.

## Verification

No Glific feature returns a built-in "AI couldn't answer" signal, so the guidance relies on the org configuring a consistent fallback phrase in the assistant's Instructions and branching on it - this matches how orgs actually do this today per the linked Discord thread. The claim that the label still applies correctly a few nodes after `Wait for Response` (as long as no other `Wait for Response` intervenes) is grounded in `glific/glific`'s `add_input_labels` behavior verified while writing #644 (it labels `context.last_message`, which is only overwritten when a new inbound message resumes the flow).

## Test plan

- [ ] Docs site renders the new section and links correctly
- [ ] Reviewer confirms this matches the pattern recommended on Discord

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Open a ticket with a human agent” guide with the latest revision date.
  * Added a new use case for escalating unanswered AI queries to a human agent, including a consistent fallback phrase, tagging the original incoming message, and opening/routing a ticket using the original question (plus handling the webhook call failure path).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->