### PR TITLE
docs: FAQ for 400 error when resuming a flow via API

### DIFF
--- a/docs/8. FAQ/Resolving 400 Error When Resuming a Flow via API.md
+++ b/docs/8. FAQ/Resolving 400 Error When Resuming a Flow via API.md
@@ -1,3 +1,15 @@
+<h3>
+ <table>
+  <tr>
+    <td><b>5 minutes read</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Level: Advanced</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: July 2026</b></td>
+  </tr>
+</table>
+</h3>
+
+
+
 ## Why do I get a 400 error when resuming a flow via API?
 
 If your flow uses the **Wait for Results** node, you pause the flow and resume it later (for example, once a long-running webhook on your backend finishes) by calling Glific's `resumeContactFlow` API. A common mistake when calling this API results in an HTTP `400 Bad Request`, instead of the expected `200` response.

--- a/docs/8. FAQ/Resolving 400 Error When Resuming a Flow via API.md
+++ b/docs/8. FAQ/Resolving 400 Error When Resuming a Flow via API.md
@@ -1,0 +1,63 @@
+## Why do I get a 400 error when resuming a flow via API?
+
+If your flow uses the **Wait for Results** node, you pause the flow and resume it later (for example, once a long-running webhook on your backend finishes) by calling Glific's `resumeContactFlow` API. A common mistake when calling this API results in an HTTP `400 Bad Request`, instead of the expected `200` response.
+
+### Root cause
+
+`resumeContactFlow` accepts a `result` argument of type `Json`. Glific's `Json` scalar only knows how to parse a **JSON-encoded string** - it does not accept a raw JSON/GraphQL object as the value.
+
+If you pass `result` as a plain object (either written inline in the GraphQL query, or as an object inside your `variables`), the query fails GraphQL's validation step before it ever reaches Glific's resolver logic, and the API responds with a `400` status and an `"Argument \"result\" has invalid value ..."` message.
+
+This is different from an application-level error (for example, resuming a contact who has no flow waiting for a result), which Glific returns as a normal `200` response with the error described inside the `errors` field of the response body.
+
+### Incorrect - raw object passed for `result`
+
+```graphql
+mutation {
+  resumeContactFlow(
+    flowId: 1
+    contactId: 2
+    result: { status: "success", message: "done" }
+  ) {
+    success
+    errors {
+      key
+      message
+    }
+  }
+}
+```
+
+This throws a `400` error because `result` is not a JSON-encoded string.
+
+### Correct - JSON-encoded string passed for `result`
+
+```graphql
+mutation resumeContactFlow($flowId: ID!, $contactId: ID!, $result: Json) {
+  resumeContactFlow(flowId: $flowId, contactId: $contactId, result: $result) {
+    success
+    errors {
+      key
+      message
+    }
+  }
+}
+```
+
+Variables:
+
+```json
+{
+  "flowId": "1",
+  "contactId": "2",
+  "result": "{\"status\": \"success\", \"message\": \"done\"}"
+}
+```
+
+Notice that the value of `result` is a **string** that itself contains escaped JSON, not a nested JSON object. This is true whether you send `result` inline in the query or via `variables`.
+
+### Other things to check if you still see a 400
+
+- Make sure the request body follows the standard GraphQL-over-HTTP format, i.e. a JSON object with `query` and `variables` keys - not `flowId`/`contactId`/`result` sent as top-level REST parameters.
+- Make sure `Content-Type: application/json` is set on the request.
+- Double check the query syntax itself (matching braces, no trailing commas) - a `400` almost always means the query failed to parse/validate, while errors from Glific's business logic (invalid flow/contact id, no active "Wait for Results" context, etc.) come back as a `200` with an `errors` array in the response body.


### PR DESCRIPTION
## Summary
- Adds a FAQ entry explaining why calling `resumeContactFlow` (used to resume a flow paused at a "Wait for Results" node) can return an HTTP 400.
- Root cause traced in the `glific/glific` backend: the `result` argument is typed `Json`, and Glific's custom `Json` scalar only parses a JSON-encoded **string** (see `parse(&decode_json/1)` in `generic_types.ex`, which only handles `Input.String`/`Input.Null`). Passing a raw JSON object fails GraphQL validation and Absinthe returns a 400, distinct from application-level errors which come back as 200 with an `errors` array.
- Includes an incorrect vs. correct example (inline query and variables form) plus a checklist of other things to check for a genuine 400.

Closes #322

## Test plan
- [x] Rendered the markdown locally to confirm formatting/code blocks are correct
- [x] Verified the file is picked up by the autogenerated FAQ sidebar (no manual sidebar entry needed)
- [x] Reviewer to confirm this matches the root cause reported in the linked Discord thread (not accessible to me)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for resolving HTTP 400 errors when resuming a flow through the API.
  * Clarified the expected request format, including how to pass JSON data correctly.
  * Included examples of incorrect vs. correct GraphQL request usage and when to expect HTTP 400 vs. application-level errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->