### PR TITLE
docs: update Assistant documentation for recent frontend changes

### DIFF
--- a/docs/5. Integrations/Creating and modifying assistants in Glific.md
+++ b/docs/5. Integrations/Creating and modifying assistants in Glific.md
@@ -3,7 +3,7 @@
   <tr>
     <td><b>3 minutes read</b></td>
     <td style={{ paddingLeft: '40px' }}><b>Level: Advanced</b></td>
-    <td style={{ paddingLeft: '40px' }}><b>Last Updated: April 2026</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: July 2026</b></td>
   </tr>
 </table>
 </h4>
@@ -12,7 +12,7 @@
 This doc details how to create new assistants, modify the created assistants and how to use these in your Glific flows. 
 
 ## Creating a new assistant
-1. From the assistant list page, click on “Create new assistant”
+1. From the assistant list page, click on “Create new assistant”. This opens a blank creation form - no assistant is created yet at this point.
 <img width="1406" height="765" alt="Screenshot 2026-04-14 at 2 46 48 PM" src="https://github.com/user-attachments/assets/3ac96677-8fe2-46b3-bff6-b5c26e1ccfb6" />
 
 2. Fill out the details needed,
@@ -20,14 +20,22 @@ This doc details how to create new assistants, modify the created assistants and
 - Select a model
 - Add your prompt 
 - Add files to create a knowledge base 
-- Set the temperature 
+- Set the temperature
+
+Note: The model dropdown shows a fixed list of supported models (currently `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`), rather than fetching every model available on the provider's account. If you need a model that isn't listed, reach out to the Glific team.
 <img width="711" height="835" alt="Screenshot 2026-04-14 at 2 58 36 PM" src="https://github.com/user-attachments/assets/5e2c0741-28ce-4e63-b545-0de08ba866cf" />
 
-3. Click on save to create the assistant. 
+3. Click on save. This is the point the assistant is actually created - nothing is saved to Glific until you click save here.
 4. This navigates to the assistant versions listing page. 
 <img width="1233" height="750" alt="Screenshot 2026-04-14 at 2 59 16 PM" src="https://github.com/user-attachments/assets/9078b2a2-24d4-4621-895b-c3f84f257caf" />
 
 5. From here, copy the assistant id and use it in the flow.
+
+## Assistant status
+Each assistant in the list page shows a status chip, so you can tell at a glance whether it's ready to use:
+- Ready - the assistant is live and usable in flows.
+- In Progress - a new version is being prepared (for example, right after you save changes or add files). Wait for this to finish before using the assistant.
+- Failed - the last update didn't complete successfully. The assistant continues to run on its previous live version; check the assistant for details and try saving your changes again.
 
 ## Modifying an assistant 
 1. From the assistant list page, click on “edit” the assistant action.
@@ -36,6 +44,15 @@ This doc details how to create new assistants, modify the created assistants and
 2. This takes to the assistant version listing page 
 3. Make the required changes to the assistant 
 4. Changing the model, changing the prompt, adding or removing files from the knowledge base, or changing the temperature of the assistant leads to showing “unsaved changes” 
+
+### Uploading files to the knowledge base
+When you add files to an assistant's knowledge base:
+- Each file uploads on its own and shows its own progress - a clock icon while it's queued, a spinner while uploading, a green check once attached, or an error icon if it failed.
+- Hovering over a failed file's error icon shows the reason it failed.
+- Failed files can be retried individually, using the retry button next to that file, without having to re-select and re-upload every other file.
+- You can't save your changes while any file is still in a failed state - remove it or retry it first.
+- Files larger than 20 MB are rejected with a warning. If you select multiple files at once and any of them is over the limit, none of them are uploaded - remove the oversized file(s) and try again.
+
 <img width="1233" height="730" alt="Screenshot 2026-04-14 at 3 00 53 PM" src="https://github.com/user-attachments/assets/af8f42d4-9072-4722-af80-eb0874b301d5" />
 
 5. Click on “save” to save the modifications done.
@@ -47,12 +64,17 @@ This doc details how to create new assistants, modify the created assistants and
 <img width="1228" height="718" alt="Screenshot 2026-04-14 at 3 04 25 PM" src="https://github.com/user-attachments/assets/ba351b06-8b51-4094-8556-cb603cf71263" />
 
 
-## Copying the assistants
-1. In the assistants list page, there is an action to “copy” the assistants
-<img width="1091" height="404" alt="Screenshot 2026-04-14 at 2 47 02 PM" src="https://github.com/user-attachments/assets/c45fc0a0-fb45-4929-9ba9-497ce1a9aab5" />
+## Cloning an assistant
+A `Clone Assistant` button is available when editing an assistant, but only for legacy assistants with a knowledge base created before February 10, 2026. If you don't see the button, your assistant either isn't eligible or has already been cloned.
 
-2. This creates a replica of the presently live version of the assistant, including the prompt, temperature and the knowledge base. 
-3. This action is needed in order to modify knowledge bases associated with assistants created before 10th March 2026. 
+1. Open the assistant you want to clone (from the assistant list page, click "edit" on its action).
+2. Click `Clone Assistant`.
+3. A confirmation dialog, "Cloning May Affect Responses," explains that a cloned assistant may behave differently from the original, and recommends reviewing responses or running evaluations after cloning. Click `Proceed` to continue, or cancel to back out.
+4. While cloning runs, the button shows `Cloning` with a spinner. This can take a little while, since the assistant's files are downloaded from OpenAI and re-uploaded to the new assistant.
+5. Once done, you'll see a success notification and the button becomes disabled with an "Already cloned" tooltip - each eligible assistant can only be cloned once.
+6. If cloning fails, the button changes to `Retry cloning` so you can try again without repeating the earlier steps.
+
+Cloning creates a replica of the assistant's presently live version, including the prompt, temperature, and knowledge base, so you can modify the knowledge base on the new copy - something that isn't possible directly on these older, legacy assistants.
 
 
 ### Main points to note about assistant id and set as live action

--- a/docs/5. Integrations/Creating and modifying assistants in Glific.md
+++ b/docs/5. Integrations/Creating and modifying assistants in Glific.md
@@ -13,7 +13,8 @@ This doc details how to create new assistants, modify the created assistants and
 
 ## Creating a new assistant
 1. From the assistant list page, click on “Create new assistant”. This opens a blank creation form - no assistant is created yet at this point.
-<img width="1406" height="765" alt="Screenshot 2026-04-14 at 2 46 48 PM" src="https://github.com/user-attachments/assets/3ac96677-8fe2-46b3-bff6-b5c26e1ccfb6" />
+
+<img width="1464" height="833" alt="image" src="https://github.com/user-attachments/assets/acef01c0-c6dd-48eb-86b6-fd29edb5f150" />
 
 2. Fill out the details needed,
 - Name of the assistant 
@@ -23,11 +24,12 @@ This doc details how to create new assistants, modify the created assistants and
 - Set the temperature
 
 Note: The model dropdown shows a fixed list of supported models (currently `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`), rather than fetching every model available on the provider's account. If you need a model that isn't listed, reach out to the Glific team.
-<img width="711" height="835" alt="Screenshot 2026-04-14 at 2 58 36 PM" src="https://github.com/user-attachments/assets/5e2c0741-28ce-4e63-b545-0de08ba866cf" />
+
+<img width="1467" height="838" alt="image" src="https://github.com/user-attachments/assets/280a164e-dfca-4cb1-839b-2a9eab077602" />
 
 3. Click on save. This is the point the assistant is actually created - nothing is saved to Glific until you click save here.
 4. This navigates to the assistant versions listing page. 
-<img width="1233" height="750" alt="Screenshot 2026-04-14 at 2 59 16 PM" src="https://github.com/user-attachments/assets/9078b2a2-24d4-4621-895b-c3f84f257caf" />
+<img width="1458" height="838" alt="image" src="https://github.com/user-attachments/assets/64fee444-59d7-4b49-b35f-b5486bee3348" />
 
 5. From here, copy the assistant id and use it in the flow.
 

--- a/docs/5. Integrations/Filesearch Using OpenAI Assistants.md
+++ b/docs/5. Integrations/Filesearch Using OpenAI Assistants.md
@@ -4,7 +4,7 @@
     <tr>
       <td><b>6 minutes read</b></td>
       <td style={{ paddingLeft: 40 }}><b> Level: Advanced</b></td>
-      <td style={{ paddingLeft: 40 }}><b>Last Updated: April 2026</b></td>
+      <td style={{ paddingLeft: 40 }}><b>Last Updated: July 2026</b></td>
     </tr>
   </table>
 </h3>
@@ -30,7 +30,7 @@ Glific’s File Search using OpenAI Assistant enables users to upload documents 
 ## How to Create an Assistant in Glific
 
 #### Step 1: Create a new AI Assistant
-Click on `AI Assistant` from the left sidebar, then select `Create Assistant` to generate a blank assistant.
+Click on `AI Assistant` from the left sidebar, then select `Create Assistant`. This opens the assistant creation form - nothing is created until you fill it in and save.
 
 <img width="1464" height="833" alt="Screenshot 2026-04-09 at 2 26 06 PM" src="https://github.com/user-attachments/assets/74d8515e-aed1-4267-95ea-fe33b421ce9c" />
 
@@ -41,7 +41,7 @@ Define the following parameters:
 
 - Provide a name to the assistant.
 
-- Choose the model from the drop-down list.
+- Choose the model from the drop-down list. This list shows a fixed set of supported models (currently `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`) rather than every model available on the provider's account.
 
 <img width="490" height="207" alt="image" src="https://github.com/user-attachments/assets/29577251-c967-438a-b2d4-ffb702ffe650" />
 
@@ -66,6 +66,7 @@ These files will be utilized by the assistant to generate responses and each fil
 - Once the files are added, click on `Save`. This will show the status of the Assistant setup. 
     - Ready — assistant is live and usable
     - In Progress — a new version is being prepared
+    - Failed — the last update didn't complete successfully; the assistant keeps running on its previous live version
 
 
 <img width="1033" height="635" alt="image" src="https://github.com/user-attachments/assets/8087fe11-4022-4e5d-8751-6a3124e8147c" />

--- a/docs/5. Integrations/Filesearch Using OpenAI Assistants.md
+++ b/docs/5. Integrations/Filesearch Using OpenAI Assistants.md
@@ -20,71 +20,13 @@ Glific’s File Search using OpenAI Assistant enables users to upload documents 
 - There is a need to build an automated knowledge assistant for your organisation.
 - Help users get instant responses.
 
-### This document guides you through three main parts:
-- Creating an OpenAI Assistant  
+### This document guides you through:
 - Using the Assistant in your Flows (including handling follow-up questions)  
 - Handling Voice Inputs and Responses  
 
+To create or modify an assistant, see [Creating and modifying AI assistants in Glific](https://glific.github.io/docs/docs/Integrations/Creating%20and%20modifying%20assistants%20in%20Glific/).
+
 ---
-
-## How to Create an Assistant in Glific
-
-#### Step 1: Create a new AI Assistant
-Click on `AI Assistant` from the left sidebar, then select `Create Assistant`. This opens the assistant creation form - nothing is created until you fill it in and save.
-
-<img width="1464" height="833" alt="Screenshot 2026-04-09 at 2 26 06 PM" src="https://github.com/user-attachments/assets/74d8515e-aed1-4267-95ea-fe33b421ce9c" />
-
-
-#### Step 2: Fill in the Assistant Details
-
-Define the following parameters:
-
-- Provide a name to the assistant.
-
-- Choose the model from the drop-down list. This list shows a fixed set of supported models (currently `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`) rather than every model available on the provider's account.
-
-<img width="490" height="207" alt="image" src="https://github.com/user-attachments/assets/29577251-c967-438a-b2d4-ffb702ffe650" />
-
-
-- Provide a system prompt in the `Instructions` field.  
-  *[Click Here](https://glific.org/a-simple-guide-to-using-large-language-models/#prompt) to read more on prompt engineering.*
-- Files (.csv, .doc, .docx, .html, .java, .md, .pdf, .pptx, .txt) can be uploaded by clicking on `Manage Files`. 
-These files will be utilized by the assistant to generate responses and each file will take approx 15 secs to upload.  
-  
-- Set the `Temperature` (between 0 to 1). A higher value increases creativity/randomness.  
-  *Recommended: keep temperature at 0.*
-
- **Note:** The quality of the bot’s response depends on the prompt. Give appropriate prompts based on your use case.
-
-
-#### Step 3: Save Your Assistant
-
-- Click on the upload files button to add files. Remember that each file can be uploaded one by one.
-
-<img width="474" height="309" alt="image" src="https://github.com/user-attachments/assets/f43bc8aa-a30f-4615-af7a-9c96d1d82bc2" />
-
-- Once the files are added, click on `Save`. This will show the status of the Assistant setup. 
-    - Ready — assistant is live and usable
-    - In Progress — a new version is being prepared
-    - Failed — the last update didn't complete successfully; the assistant keeps running on its previous live version
-
-
-<img width="1033" height="635" alt="image" src="https://github.com/user-attachments/assets/8087fe11-4022-4e5d-8751-6a3124e8147c" />
-
-
-#### Step 4: Copy the Assistant ID
-
-- Once created, copy the `Assistant ID` shown below the assistant name. 
-
-- This ID will be used in the webhook nodes in the flow editor.
-
-<img width="650" height="748" alt="Screenshot 2026-04-09 at 2 43 40 PM" src="https://github.com/user-attachments/assets/6be25951-9c1f-417d-ae76-2b9735d361ca" />
-
-**Please Note:** Assistants created before 10 March 2026 that include a Knowledge Base will have a Clone button. This allows you to create a copy of the assistant, make edits, add a new files, and reuse it as needed.
-Assistants created without a Knowledge Base will not have the Clone option available.
-If you need to update such assistants, you may have to create a new one with the required Knowledge Base configuration.
-
-<img width="524" height="675" alt="image" src="https://github.com/user-attachments/assets/e68cda40-fadd-46cd-bb1b-c988a612731d" />
 
 ## Using the OpenAI Assistant in Floweditor
 The following sections explain how to use an assistant to answer questions or create conversations.
@@ -132,7 +74,7 @@ _Screenshot of example flow set up is given below_
 <img width="628" height="435" alt="Screenshot 2025-12-02 at 6 10 59 PM" src="https://github.com/user-attachments/assets/aff3ba8d-e5d0-4958-b10c-2bfa481d2128" />
 
 - In `question` parameter enter the flow variable containing the question asked by the user. In the given example `question` is the `result name`, hence provided `@result.question` in the question parameter.
-- In `assistant_id` enter the assistant id obtained in step 4 of "How to Create an OpenAI Assistant in Glific"
+- In `assistant_id` enter the assistant ID, copied as described in [Creating and modifying AI assistants in Glific](https://glific.github.io/docs/docs/Integrations/Creating%20and%20modifying%20assistants%20in%20Glific/)
 
   <img width="623" height="438" alt="Screenshot 2025-12-02 at 9 18 23 AM" src="https://github.com/user-attachments/assets/880a4181-bd79-4d04-92aa-c0d502456bd5" />
 
@@ -198,7 +140,7 @@ Pass the following paramters in the function body.
 
 - For `contact ` keep this value as `@contact` as mentioned in the screenshot.
 - `speech` is the result name which is storing the voice note sent by the user.
-- `assistant_id` is the assistant id obtained in step 4 of "How to Create an OpenAI Assistant in Glific.
+- `assistant_id` is the assistant ID, copied as described in [Creating and modifying AI assistants in Glific](https://glific.github.io/docs/docs/Integrations/Creating%20and%20modifying%20assistants%20in%20Glific/).
 - `source_langauge` is the expected language of the user.
 - `target_language` is the language that the response voice note needs to be in.
 


### PR DESCRIPTION
## Summary

Fixes #588

Updates both AI Assistant docs ("Creating and modifying assistants in Glific" and "File Search Using OpenAI Assistants") to reflect the 5 features listed in the issue, all verified directly against the referenced frontend PR diffs rather than the issue description alone:

1. **Manual assistant creation** (glific-frontend#3754) - corrected the "Create new assistant" step to note that clicking it just opens the form; the assistant isn't created until you fill it in and save. Previously the docs (and the old code) implied a blank assistant was auto-provisioned first.
2. **Hardcoded model options** (glific-frontend#3802) - added a note that the model dropdown shows a fixed list (`gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`) rather than fetching from the backend.
3. **Assistant status display** (glific-frontend#3829, #3836) - added an "Assistant status" section documenting all three chip states shown in the list: Ready, In Progress, and Failed (the issue only mentioned two, but the actual code also has a Failed state).
4. **Queued file uploads** (glific-frontend#3854) - added an "Uploading files to the knowledge base" section: per-file progress icons, per-file error/retry, save blocked while any file is failed, and the 20MB size limit (verified that exceeding it rejects the whole batch, not just the oversized file).
5. **User-initiated assistant cloning** (glific-frontend#3857) - replaced the old "Copying the assistants" section (which described a list-page "copy" action that no longer exists) with "Cloning an assistant", covering the confirmation dialog copy, Cloning/Retry cloning button states, the "Already cloned" disabled state, and the legacy-assistant eligibility restriction.

## Note on the cloning eligibility date

The issue states assistants are eligible if "Created before February 10, 2026." I couldn't find that exact date encoded anywhere in `glific/glific` (eligibility is driven by a `clone_status` field that isn't "none", set via what looks like an out-of-band data migration) - I've used the date as given in the issue since I have no way to verify it independently. Flagging in case it needs correcting.

## Verification

Read the full diffs of all 5 referenced glific-frontend PRs (#3754, #3802, #3829, #3836, #3854, #3857) to confirm exact UI copy, button labels, and behavior rather than paraphrasing the issue.

## Test plan

- [ ] Docs site renders both updated pages correctly
- [ ] Reviewer confirms the clone eligibility date and any other product details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified when an assistant is created (only after saving) and updated model dropdown guidance, including what to do when a model isn’t listed.
  * Expanded “modify assistant” instructions with knowledge-base upload states, error visibility, per-file retry behavior, save restrictions during failed uploads, and a 20MB file-size limit (including multi-file selection behavior).
  * Replaced “copying assistants” with “cloning an assistant,” including eligibility, confirmation about response differences, cloning progress/completion behavior, and retry on failure.
  * Updated “Last Updated” to July 2026 and revised File Search flow wording and assistant ID references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->