### PR TITLE
docs: add FAQ for updating WhatsApp business profile info

### DIFF
--- a/docs/8. FAQ/Updating Your WhatsApp Business Profile Info.md
+++ b/docs/8. FAQ/Updating Your WhatsApp Business Profile Info.md
@@ -1,0 +1,37 @@
+<h3>
+ <table>
+  <tr>
+    <td><b>3 minutes read</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Level: Beginner </b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: July 2026</b></td>
+  </tr>
+</table>
+</h3>
+
+# Updating Your WhatsApp Business Profile Info
+
+When a contact taps on your chatbot's name in WhatsApp, they see a business profile - your description, address, email, and website links. This information isn't managed in Glific. It's part of your WhatsApp Business Profile, which you manage through Gupshup (the WhatsApp Business API provider Glific uses to send and receive messages).
+
+## What you can update
+
+- Profile photo
+- Business description (the short summary shown at the top of the profile)
+- Website URLs (your primary website, plus any additional ones)
+- Business email address
+- Physical business address
+- About text (shown when a contact taps the info icon at the top of the chat)
+- Contact details (phone numbers and social media handles)
+
+## Steps to update your business profile
+
+1. Log in to your Gupshup account - the same account used when you [set up Gupshup](https://glific.github.io/docs/docs/Pre%20Onboarding/Gupshup%20Setup/) for your chatbot.
+2. Go to `Dashboard` > select your app > `Profile`.
+3. Update whichever fields you need - photo, description, website, email, address, about text, or contact details.
+4. Save your changes.
+
+Note: These updates go to WhatsApp directly, not through Glific, so there's nothing further to configure in Glific for this to take effect. It can take a little time for the changes to show up consistently across Android, iOS, Web, and Desktop WhatsApp for your contacts.
+
+---
+
+You can read more about related setup here:
+- [Gupshup Setup](https://glific.github.io/docs/docs/Pre%20Onboarding/Gupshup%20Setup/)

--- a/docs/8. FAQ/Updating Your WhatsApp Business Profile Info.md
+++ b/docs/8. FAQ/Updating Your WhatsApp Business Profile Info.md
@@ -18,7 +18,7 @@ When a contact taps on your chatbot's name in WhatsApp, they see a business prof
 - Business description (the short summary shown at the top of the profile)
 - Website URLs (your primary website, plus any additional ones)
 - Business email address
-- Physical business address
+- Business address
 - Business category
 - Contact details (phone number)
 

--- a/docs/8. FAQ/Updating Your WhatsApp Business Profile Info.md
+++ b/docs/8. FAQ/Updating Your WhatsApp Business Profile Info.md
@@ -10,7 +10,7 @@
 
 # Updating Your WhatsApp Business Profile Info
 
-When a contact taps on your chatbot's name in WhatsApp, they see a business profile - your description, address, email, and website links. This information isn't managed in Glific. It's part of your WhatsApp Business Profile, which you manage through Gupshup (the WhatsApp Business API provider Glific uses to send and receive messages).
+When a contact taps on your chatbot's name in WhatsApp, they see a business profile - your description, address, email, and website links. This information isn't managed in Glific. It's part of your WhatsApp Business Profile, which you manage through Meta's [WhatsApp Manager](https://business.facebook.com/latest/whatsapp_manager/phone_numbers/) - using the same Meta Business Account connected to your chatbot's WhatsApp number when you [set up Gupshup](https://glific.github.io/docs/docs/Pre%20Onboarding/Gupshup%20Setup/) (the WhatsApp Business API provider Glific uses to send and receive messages).
 
 ## What you can update
 
@@ -19,19 +19,14 @@ When a contact taps on your chatbot's name in WhatsApp, they see a business prof
 - Website URLs (your primary website, plus any additional ones)
 - Business email address
 - Physical business address
-- About text (shown when a contact taps the info icon at the top of the chat)
-- Contact details (phone numbers and social media handles)
+- Business category
+- Contact details (phone number)
 
 ## Steps to update your business profile
 
-1. Log in to your Gupshup account - the same account used when you [set up Gupshup](https://glific.github.io/docs/docs/Pre%20Onboarding/Gupshup%20Setup/) for your chatbot.
-2. Go to `Dashboard` > select your app > `Profile`.
-3. Update whichever fields you need - photo, description, website, email, address, about text, or contact details.
+1. Go to [WhatsApp Manager](https://business.facebook.com/latest/whatsapp_manager/phone_numbers/) in Meta Business Manager, and log in with the Meta Business Account linked to your chatbot's WhatsApp number.
+2. Under `Phone numbers`, select your chatbot's WhatsApp number, then open its `Profile`.
+3. Update whichever fields you need - photo, description, website, email, address, category, or contact details.
 4. Save your changes.
 
-Note: These updates go to WhatsApp directly, not through Glific, so there's nothing further to configure in Glific for this to take effect. It can take a little time for the changes to show up consistently across Android, iOS, Web, and Desktop WhatsApp for your contacts.
-
----
-
-You can read more about related setup here:
-- [Gupshup Setup](https://glific.github.io/docs/docs/Pre%20Onboarding/Gupshup%20Setup/)
+Note: These updates go to WhatsApp directly, not through Glific, so there's nothing further to configure in Glific for this to take effect. It can take a little time for the changes to show up consistently across Android, iOS, Web, and Desktop WhatsApp for your contacts. Unlike changing your WhatsApp Business display name, these profile updates don't need Meta's verification, so they take effect as soon as you save.


### PR DESCRIPTION
## Summary

Fixes #538

Adds a new FAQ page, "Updating Your WhatsApp Business Profile Info," answering how to update the address, email, description, and website links shown when a contact taps your chatbot's name in WhatsApp (matching the screenshot in the issue).

This info isn't managed in Glific - it's the WhatsApp Business Profile, managed through Gupshup. The page explains:
- What's editable: profile photo, business description, website URLs, email, address, About text, and contact details
- The steps to update it: Gupshup Dashboard > your app > `Profile` tab
- That changes go directly to WhatsApp, so nothing further needs to be configured in Glific, and it can take a little time to show up consistently across devices

Cross-links to the existing "Gupshup Setup" doc (same account these steps use) rather than duplicating the account setup instructions.

## Verification

Confirmed the exact navigation path and editable fields against Gupshup's own documentation (`docs.gupshup.io/docs/profile` and `docs.gupshup.io/docs/manage-business-profile`), since Glific doesn't control this profile info itself.

## Test plan

- [ ] Docs site renders the new FAQ page correctly
- [ ] Reviewer confirms the Gupshup navigation steps still match the current dashboard UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ page with guidance on updating WhatsApp Business Profile details, including description, address, email, and website links.
  * Documented how to make changes via Meta’s WhatsApp Manager.
  * Clarified that profile updates occur directly in WhatsApp and may take time to reflect consistently across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->