### PR TITLE
docs: document description field for dynamic interactive message list options

### DIFF
--- a/docs/4. Product Features/11. Link Google Sheets/04. Dynamic Interactive Messages via Google Sheet.md
+++ b/docs/4. Product Features/11. Link Google Sheets/04. Dynamic Interactive Messages via Google Sheet.md
@@ -3,7 +3,7 @@
   <tr>
     <td><b>5 minutes read</b></td>
     <td style={{ paddingLeft: '40px' }}><b>Level: Beginner </b></td>
-    <td style={{ paddingLeft: '40px' }}><b>Last Updated: July 2026</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: August 2026</b></td>
   </tr>
 </table>
 </h3>
@@ -107,10 +107,13 @@ In the **Send Contact an Interactive Message** node:
 2. Enable **Dynamic Fields**.
 3. Enter the number of variables required.
 
-For example, if your Google Sheet contains **8 options**, enter:
+For example, if your Google Sheet contains **10 options**, enter:
+
+<img width="584" height="559" alt="image" src="https://github.com/user-attachments/assets/b219a7ac-25fc-41dc-b271-cbc83ba4932d" />
+
 
 ```text
-8
+10
 ```
 
 For each variable:
@@ -123,16 +126,16 @@ Example:
 
 | ID      | Variable                 | Description                    |
 | ------- | ------------------------ | ------------------------------- |
-| option1 | `@results.sheet.course1` | `@results.sheet.course1_desc`  |
-| option2 | `@results.sheet.course2` | `@results.sheet.course2_desc`  |
-| option3 | `@results.sheet.course3` | `@results.sheet.course3_desc`  |
-| option4 | `@results.sheet.course4` | `@results.sheet.course4_desc`  |
+| option1 | `@results.sheet.option1` | `@results.sheet.option1_desc`  |
+| option2 | `@results.sheet.option2` | `@results.sheet.option2_desc`  |
+| option3 | `@results.sheet.option3` | `@results.sheet.option3_desc`  |
+| option4 | `@results.sheet.option4` | `@results.sheet.option4_desc`  |
 
 Continue the same pattern for all remaining options.
 
 Descriptions longer than WhatsApp's 72-character limit for list item descriptions are automatically trimmed.
 
-<img width="668" height="706" alt="image" src="https://github.com/user-attachments/assets/26bff284-39c8-4399-95bb-21b42959badc" />
+<img width="586" height="642" alt="image" src="https://github.com/user-attachments/assets/23b4a24a-9d9c-408f-b741-bdfd23d15720" />
 
 
 ## Step 6: Test the Flow
@@ -141,7 +144,7 @@ Run the flow and preview the interactive message.
 
 Glific reads the selected row from the Google Sheet and replaces the placeholder options with the values stored in the sheet.
 
-<img width="329" height="584" alt="image" src="https://github.com/user-attachments/assets/eda34e7d-a04c-488b-aaa9-7173b77dc990" />
+<img width="376" height="568" alt="image" src="https://github.com/user-attachments/assets/580a172f-77c2-432f-ac43-1cf635ffd579" />
 
 
 ## Benefits

--- a/docs/4. Product Features/11. Link Google Sheets/04. Dynamic Interactive Messages via Google Sheet.md
+++ b/docs/4. Product Features/11. Link Google Sheets/04. Dynamic Interactive Messages via Google Sheet.md
@@ -3,7 +3,7 @@
   <tr>
     <td><b>5 minutes read</b></td>
     <td style={{ paddingLeft: '40px' }}><b>Level: Beginner </b></td>
-    <td style={{ paddingLeft: '40px' }}><b>Last Updated: June 2026</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: July 2026</b></td>
   </tr>
 </table>
 </h3>
@@ -32,6 +32,8 @@ For example:
 | Key | course1 | course2 | course3 | course4 |
 | --- | ------- | ------- | ------- | ------- |
 | 1   | English | Hindi   | Tamil   | Kannada |
+
+If you also want to show a description under each option (list messages only), add a column for it too - for example `course1_desc`, `course2_desc`, and so on.
 
 > **Note**
 >
@@ -114,18 +116,21 @@ For example, if your Google Sheet contains **8 options**, enter:
 For each variable:
 
 * **ID:** Any unique identifier.
-* **Value:** The corresponding value retrieved from the Google Sheet.
+* **Value:** The corresponding value retrieved from the Google Sheet. This becomes the option's title.
+* **Description:** Optional. Another value retrieved from the Google Sheet, shown as smaller text under the option's title (list messages only - reply buttons don't have a description). Leave it blank if you don't need one.
 
 Example:
 
-| ID      | Variable                 |
-| ------- | ------------------------ |
-| option1 | `@results.sheet.course1` |
-| option2 | `@results.sheet.course2` |
-| option3 | `@results.sheet.course3` |
-| option4 | `@results.sheet.course4` |
+| ID      | Variable                 | Description                    |
+| ------- | ------------------------ | ------------------------------- |
+| option1 | `@results.sheet.course1` | `@results.sheet.course1_desc`  |
+| option2 | `@results.sheet.course2` | `@results.sheet.course2_desc`  |
+| option3 | `@results.sheet.course3` | `@results.sheet.course3_desc`  |
+| option4 | `@results.sheet.course4` | `@results.sheet.course4_desc`  |
 
 Continue the same pattern for all remaining options.
+
+Descriptions longer than WhatsApp's 72-character limit for list item descriptions are automatically trimmed.
 
 <img width="668" height="706" alt="image" src="https://github.com/user-attachments/assets/26bff284-39c8-4399-95bb-21b42959badc" />
 

--- a/docs/4. Product Features/11. Link Google Sheets/05. List options in Interactive Messages.md
+++ b/docs/4. Product Features/11. Link Google Sheets/05. List options in Interactive Messages.md
@@ -3,7 +3,7 @@
   <tr>
     <td><b>5 minutes read</b></td>
     <td style={{ paddingLeft: '40px' }}><b>Level: Beginner </b></td>
-    <td style={{ paddingLeft: '40px' }}><b>Last Updated: July 2026</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: August 2026</b></td>
   </tr>
 </table>
 </h3>

--- a/docs/4. Product Features/11. Link Google Sheets/05. List options in Interactive Messages.md
+++ b/docs/4. Product Features/11. Link Google Sheets/05. List options in Interactive Messages.md
@@ -3,7 +3,7 @@
   <tr>
     <td><b>5 minutes read</b></td>
     <td style={{ paddingLeft: '40px' }}><b>Level: Beginner </b></td>
-    <td style={{ paddingLeft: '40px' }}><b>Last Updated: June 2026</b></td>
+    <td style={{ paddingLeft: '40px' }}><b>Last Updated: July 2026</b></td>
   </tr>
 </table>
 </h3>
@@ -76,7 +76,7 @@ For quiz -
   
   <img width="355" height="398" alt="Screenshot 2025-10-09 at 2 43 44 PM" src="https://github.com/user-attachments/assets/59ba324d-ba05-4a06-891c-5cd2db1c58a1" />
   
-  <li> The <code>Use Dynamic Fields</code> option is enabled, and since only two options need to be shown to the user, the Read Option Limit is set to 2. Corresponding IDs and variable names are configured to fetch the option values from the correct columns in the linked Google Sheet. </li>
+  <li> The <code>Use Dynamic Fields</code> option is enabled, and since only two options need to be shown to the user, the Read Option Limit is set to 2. Corresponding IDs and variable names are configured to fetch the option values from the correct columns in the linked Google Sheet. A description can optionally be configured the same way for each option - see <a href="https://glific.github.io/docs/docs/Product%20Features/Link%20Google%20Sheets/Dynamic%20Interactive%20Messages%20via%20Google%20Sheet/">Dynamic Interactive Messages via Google Sheet</a>. </li>
 </ul>
 
 For Nested drill down – 


### PR DESCRIPTION
## Summary

Fixes #657

`glific/glific#4142` (merged via [glific/glific#5399](https://github.com/glific/glific/pull/5399) on July 21) added support for populating a WhatsApp list option's **description** from a variable - previously only the title/label could be set dynamically, and the description field was always left blank in dynamic interactive messages fed from a Google Sheet.

This updates the existing "Dynamic Interactive Messages via Google Sheet" doc (which already covered the ID/Variable setup) to document the new Description field:

- Step 1: note that you can add extra sheet columns for descriptions
- Step 5: added a Description column to the ID/Variable example table, explained it's optional and list-message-only (reply buttons have no description), and noted WhatsApp's 72-character limit (verified against the backend's `trim_field(param["description"], 72)`)

Also added a short cross-reference from the related "List options in Interactive Messages" doc, which documents the same ID/Variable config pattern in a different use case, so it doesn't go stale relative to this change.

## Verification

Confirmed end-to-end against the actual code rather than just the issue text:
- `glific/glific` PR #5399: backend now reads `param["description"]` and trims it to 72 chars
- `glific/floweditor`'s `SendInteractiveMsgForm.tsx`: the node config form already has an `id`/`variable`/`description` field triplet per row (placeholders `id {n}`, `variable {n}`, `description {n}`), so this is a fully shipped, usable feature end-to-end, not just a backend change

## Test plan

- [ ] Docs site renders the updated tables and sections correctly
- [ ] Reviewer confirms the Description field placement/behavior matches the current flow editor UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Google Sheets interactive message guides with August 2026 revision dates.
  * Added instructions for configuring optional descriptions for list message options.
  * Documented dynamic description mappings and automatic trimming when descriptions exceed WhatsApp’s 72-character limit.
  * Expanded configuration examples to include up to 10 options.
  * Added cross-reference guidance and updated screenshots for per-option descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->