### PR TITLE
docs: update documentation link in docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,7 +94,7 @@ const config = {
           items: [
             {
               label: "Documentation",
-              to: "/docs/Introduction",
+              to: "/docs",
             },
           ],
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the footer’s “Documentation” link to direct visitors to the main documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->